### PR TITLE
Fix log file name

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ fi
     echo "$(cat /home/steam/Steam/logs/stderr.txt)"
     echo
     echo workshop_log
-    echo "$(cat /home/steam/Steam/logs/Workshop_log.txt)"
+    echo "$(cat /home/steam/Steam/logs/workshop_log.txt)"
 
     exit 1
 )


### PR DESCRIPTION
The `/home/steam/Steam/logs/Workshop_log.txt` does not exist. Instead, I found the following: `/home/steam/Steam/logs/workshop_log.txt`

Fixes #2 